### PR TITLE
allow hide/show/etc to be fired when selector selects multiple elements

### DIFF
--- a/jquery.showandtell.js
+++ b/jquery.showandtell.js
@@ -9,21 +9,21 @@
  */
 (function ($) {
 
-    function applyIfExistsOrNull( fun, self, args ) {
-        return typeof fun !== 'undefined' ? fun.apply( self, args ) : null;
+    function applyIfExistsOrNull(fun, self, args) {
+        return typeof fun !== "undefined" ? fun.apply(self, args) : null;
     }
 
-    function proxy$Functions( functionProxies ) {
-        $.each( functionProxies, function( old_function_name, proxy_settings ) {
+    function proxy$Functions(functionProxies) {
+        $.each(functionProxies, function(old_function_name, proxy_settings) {
             var old_function = $.fn[old_function_name];
 
             $.fn[old_function_name] = function() {
-                var pre_result = applyIfExistsOrNull( proxy_settings.pre, this, arguments );
+                var pre_result = applyIfExistsOrNull(proxy_settings.pre, this, arguments);
 
-                var result = old_function.apply( this, arguments );
+                var result = old_function.apply(this, arguments);
 
                 var postArguments = [result, pre_result, arguments];
-                applyIfExistsOrNull( proxy_settings.post, this, postArguments );
+                applyIfExistsOrNull(proxy_settings.post, this, postArguments);
 
                 return result;
             }
@@ -31,7 +31,7 @@
     }
 
     function checkIfElementWasHidden() {
-		return $( this ).map( function() { return $( this ).is( ':hidden' ); } );
+		return $(this).map(function() { return $(this).is(":hidden"); });
     }
 
     //Only register if not already registered
@@ -43,44 +43,44 @@
         proxy$Functions({
             hide: {
                 pre: checkIfElementWasHidden,
-                post: function( result, elementWasHidden, old_args ) {
-					$( this )
-						.filter( function( idx ) { return ! elementWasHidden[idx]; } )
-						.each( function() { $( this ).triggerHandler( 'showandtell.hide' ); } );
+                post: function(result, elementWasHidden, old_args) {
+					$(this)
+						.filter(function(idx) { return ! elementWasHidden[idx]; })
+						.each(function() { $(this).triggerHandler("showandtell.hide"); });
                 }
             },
             show: {
                 pre: checkIfElementWasHidden,
-                post: function( result, elementWasHidden, old_args ) {
-					$( this )
-						.filter( function( idx ) { return elementWasHidden[idx]; } )
-						.each( function() { $( this ).triggerHandler( 'showandtell.show' ); } );
+                post: function(result, elementWasHidden, old_args) {
+					$(this)
+						.filter(function(idx) { return elementWasHidden[idx]; })
+						.each(function() { $(this).triggerHandler("showandtell.show"); });
                 }
             },
             remove: {
                 //Remove has to trigger event before removing. After removal, there is no element to
                 //  trigger the event on.
                 pre: function() {
-                    $( this )
-						.each( function() { $( this ).triggerHandler( 'showandtell.remove' ); } );
+                    $(this)
+						.each(function() { $(this).triggerHandler("showandtell.remove"); });
                 }
             },
             css: {
                 pre: checkIfElementWasHidden,
-                post: function( result, elementWasHidden, old_args ) {
-					$( this )
-						.filter( function( idx ) {
-							return ! elementWasHidden[idx] && old_args[0] == 'display' && old_args[1] == 'none' ;
-						} ).each( function() {
-							$( this ).triggerHandler( 'showandtell.cssHide' );
-							} );
+                post: function(result, elementWasHidden, old_args) {
+					$(this)
+						.filter(function(idx) {
+							return ! elementWasHidden[idx] && old_args[0] == "display" && old_args[1] == "none";
+						}).each(function() {
+							$(this).triggerHandler("showandtell.cssHide");
+						});
 
-					$( this )
-						.filter( function( idx ) {
-							return elementWasHidden[idx] && old_args[0] == 'display' && old_args[1] != 'none' ;
-						} ).each( function() {
-							$( this ).triggerHandler( 'showandtell.cssShow' );
-							} );
+					$(this)
+						.filter(function(idx) {
+							return elementWasHidden[idx] && old_args[0] == "display" && old_args[1] != "none";
+						}).each(function() {
+							$(this).triggerHandler("showandtell.cssShow");
+						});
                 }
             }
         });

--- a/jquery.showandtell.js
+++ b/jquery.showandtell.js
@@ -31,7 +31,7 @@
     }
 
     function checkIfElementWasHidden() {
-		return $(this).map(function() { return $(this).is(":hidden"); });
+        return $(this).map(function() { return $(this).is(":hidden"); });
     }
 
     //Only register if not already registered
@@ -44,17 +44,17 @@
             hide: {
                 pre: checkIfElementWasHidden,
                 post: function(result, elementWasHidden, old_args) {
-					$(this)
-						.filter(function(idx) { return ! elementWasHidden[idx]; })
-						.each(function() { $(this).triggerHandler("showandtell.hide"); });
+                    $(this)
+                        .filter(function(idx) { return ! elementWasHidden[idx]; })
+                        .each(function() { $(this).triggerHandler("showandtell.hide"); });
                 }
             },
             show: {
                 pre: checkIfElementWasHidden,
                 post: function(result, elementWasHidden, old_args) {
-					$(this)
-						.filter(function(idx) { return elementWasHidden[idx]; })
-						.each(function() { $(this).triggerHandler("showandtell.show"); });
+                    $(this)
+                        .filter(function(idx) { return elementWasHidden[idx]; })
+                        .each(function() { $(this).triggerHandler("showandtell.show"); });
                 }
             },
             remove: {
@@ -62,25 +62,25 @@
                 //  trigger the event on.
                 pre: function() {
                     $(this)
-						.each(function() { $(this).triggerHandler("showandtell.remove"); });
+                        .each(function() { $(this).triggerHandler("showandtell.remove"); });
                 }
             },
             css: {
                 pre: checkIfElementWasHidden,
                 post: function(result, elementWasHidden, old_args) {
-					$(this)
-						.filter(function(idx) {
-							return ! elementWasHidden[idx] && old_args[0] == "display" && old_args[1] == "none";
-						}).each(function() {
-							$(this).triggerHandler("showandtell.cssHide");
-						});
+                    $(this)
+                        .filter(function(idx) {
+                            return ! elementWasHidden[idx] && old_args[0] == "display" && old_args[1] == "none";
+                        }).each(function() {
+                            $(this).triggerHandler("showandtell.cssHide");
+                        });
 
-					$(this)
-						.filter(function(idx) {
-							return elementWasHidden[idx] && old_args[0] == "display" && old_args[1] != "none";
-						}).each(function() {
-							$(this).triggerHandler("showandtell.cssShow");
-						});
+                    $(this)
+                        .filter(function(idx) {
+                            return elementWasHidden[idx] && old_args[0] == "display" && old_args[1] != "none";
+                        }).each(function() {
+                            $(this).triggerHandler("showandtell.cssShow");
+                        });
                 }
             }
         });

--- a/jquery.showandtell.js
+++ b/jquery.showandtell.js
@@ -9,21 +9,21 @@
  */
 (function ($) {
 
-    function applyIfExistsOrNull(fun, self, args) {
-        return typeof fun !== "undefined" ? fun.apply(self, args) : null;
+    function applyIfExistsOrNull( fun, self, args ) {
+        return typeof fun !== 'undefined' ? fun.apply( self, args ) : null;
     }
 
-    function proxy$Functions(functionProxies) {
-        $.each(functionProxies, function(old_function_name, proxy_settings) {
+    function proxy$Functions( functionProxies ) {
+        $.each( functionProxies, function( old_function_name, proxy_settings ) {
             var old_function = $.fn[old_function_name];
 
             $.fn[old_function_name] = function() {
-                var pre_result = applyIfExistsOrNull(proxy_settings.pre, this, arguments);
+                var pre_result = applyIfExistsOrNull( proxy_settings.pre, this, arguments );
 
-                var result = old_function.apply(this, arguments);
+                var result = old_function.apply( this, arguments );
 
                 var postArguments = [result, pre_result, arguments];
-                applyIfExistsOrNull(proxy_settings.post, this, postArguments);
+                applyIfExistsOrNull( proxy_settings.post, this, postArguments );
 
                 return result;
             }
@@ -31,7 +31,7 @@
     }
 
     function checkIfElementWasHidden() {
-        return $(this).is(":hidden");
+		return $( this ).map( function() { return $( this ).is( ':hidden' ); } );
     }
 
     //Only register if not already registered
@@ -43,33 +43,44 @@
         proxy$Functions({
             hide: {
                 pre: checkIfElementWasHidden,
-                post: function(result, elementWasHidden, old_args) {
-                    if(!elementWasHidden)
-                        this.triggerHandler("showandtell.hide");
+                post: function( result, elementWasHidden, old_args ) {
+					$( this )
+						.filter( function( idx ) { return ! elementWasHidden[idx]; } )
+						.each( function() { $( this ).triggerHandler( 'showandtell.hide' ); } );
                 }
             },
             show: {
                 pre: checkIfElementWasHidden,
-                post: function(result, elementWasHidden, old_args) {
-                    if(elementWasHidden)
-                        this.triggerHandler("showandtell.show");
+                post: function( result, elementWasHidden, old_args ) {
+					$( this )
+						.filter( function( idx ) { return elementWasHidden[idx]; } )
+						.each( function() { $( this ).triggerHandler( 'showandtell.show' ); } );
                 }
             },
             remove: {
                 //Remove has to trigger event before removing. After removal, there is no element to
                 //  trigger the event on.
                 pre: function() {
-                    this.triggerHandler("showandtell.remove");
+                    $( this )
+						.each( function() { $( this ).triggerHandler( 'showandtell.remove' ); } );
                 }
             },
             css: {
                 pre: checkIfElementWasHidden,
-                post: function(result, elementWasHidden, old_args) {
-                    if(!elementWasHidden && old_args[0] == "display" && old_args[1] == "none")
-                        $(this).triggerHandler("showandtell.cssHide");
+                post: function( result, elementWasHidden, old_args ) {
+					$( this )
+						.filter( function( idx ) {
+							return ! elementWasHidden[idx] && old_args[0] == 'display' && old_args[1] == 'none' ;
+						} ).each( function() {
+							$( this ).triggerHandler( 'showandtell.cssHide' );
+							} );
 
-                    if(elementWasHidden && old_args[0] == "display" && old_args[1] != "none")
-                        $(this).triggerHandler("showandtell.cssShow");
+					$( this )
+						.filter( function( idx ) {
+							return elementWasHidden[idx] && old_args[0] == 'display' && old_args[1] != 'none' ;
+						} ).each( function() {
+							$( this ).triggerHandler( 'showandtell.cssShow' );
+							} );
                 }
             }
         });

--- a/test/fixture.html
+++ b/test/fixture.html
@@ -17,5 +17,6 @@
         <script src="unit/animate.js"></script>
         <script src="unit/children.js"></script>
         <script src="unit/bubble.js"></script>
+        <script src="unit/multi-select.js"></script>
     </body>
 </html>

--- a/test/unit/multi-select.js
+++ b/test/unit/multi-select.js
@@ -20,3 +20,171 @@ QUnit.test("hide Test (hide)", function(assert) {
     })
     .hide();
 });
+
+QUnit.test("hide invisible Test (no event)", function(assert) {
+  expect(0);
+  $('<div style="display: none;">Hello</div><div style="display: none;">Goodbye</div>')
+    .appendTo("#qunit-fixture")
+    .bind('showandtell.hide', function(event) {
+      if (event.namespace == "hide")
+        ok(false, "Hide event shouldn't have triggered");
+    })
+    .bind('showandtell.show', function(event) {
+      if (event.namespace == "show")
+      {
+        //Make sure show event does not trigger!
+        ok(false, "Show event shouldn't have triggered");
+      }
+    })
+    .hide();
+});
+
+QUnit.test("hide invisible Test (1 hide)", function(assert) {
+  expect(3);
+  $('<div style="display: none;">Hello</div><div>Goodbye</div>')
+    .appendTo("#qunit-fixture")
+    .bind('showandtell.hide', function(event) {
+      ok(true, "Event triggered");
+      ok($(this).is(":hidden"), "Element is hidden");
+
+      //Check that action and fatality is reported correctly
+      equal(event.namespace, "hide", "hide() is an action");
+    })
+    .bind('showandtell.show', function(event) {
+      if (event.namespace == "show")
+      {
+        //Make sure show event does not trigger!
+        ok(false, "Show event shouldn't have triggered");
+      }
+    })
+    .hide();
+});
+
+QUnit.test("show Test (show)", function(assert) {
+  expect(6);
+  $("<div style='display: none'>Hello</div><div style='display: none'>Goodbye</div>")
+    .appendTo("#qunit-fixture")
+    .bind('showandtell.show', function(event) {
+      ok(true, "Event triggered");
+      ok($(this).is(":visible"), "Element is visible");
+
+      //Check that action and fatality is reported correctly
+      equal(event.namespace, "show", "show() is an action");
+    })
+    .bind('showandtell.hide', function(event) {
+      if (event.namespace == "hide")
+      {
+        //Make sure show event does not trigger!
+        ok(false, "Hide event shouldn't have triggered");
+      }
+    })
+    .show();
+});
+
+
+QUnit.test("show visible Test (no event)", function(assert) {
+  expect(0);
+  $('<div>Goodbye</div>')
+    .appendTo("#qunit-fixture")
+    .bind('showandtell.show', function(event) {
+      if (event.namespace == "show")
+        ok(false, "Show event shouldn't have triggered");
+    })
+    .bind('showandtell.hide', function(event) {
+      if (event.namespace == "hide")
+        ok(false, "Hide event shouldn't have triggered");
+    })
+    .show();
+});
+
+QUnit.test("show visible Test (1 show)", function(assert) {
+  expect(3);
+  $('<div>Hello</div><div style="display: none">Goodbye</div>')
+    .appendTo("#qunit-fixture")
+    .bind('showandtell.hide', function(event) {
+        ok(false, "Hide event shouldn't have triggered");
+    })
+    .bind('showandtell.show', function(event) {
+      if (event.namespace == "show")
+      {
+      ok(true, "Event triggered");
+      ok($(this).is(":visible"), "Element is visible");
+
+      //Check that action and fatality is reported correctly
+      equal(event.namespace, "show", "show() is an action");
+      }
+    })
+    .show();
+});
+
+QUnit.test("remove Test (remove)", function(assert) {
+  expect(4);
+  $("<div>Hello</div><div>Goodbye</div>")
+    .appendTo("#qunit-fixture")
+    .bind('showandtell.remove', function(event) {
+      ok(true, "Event triggered");
+      equal(event.namespace, "remove", "remove() is an action");
+    })
+    .bind('showandtell.hide', function(event) {
+      if (event.namespace == "hide")
+        ok(false, "Hide event shouldn't have triggered");
+    })
+    .bind('showandtell.show', function(event) {
+      if (event.namespace == "show")
+        ok(false, "Show event shouldn't have triggered");
+    })
+    .remove();
+});
+
+
+QUnit.test("remove invisible Test (remove)", function(assert) {
+  expect(4);
+  $("<div style='display: none'>Hello</div><div>Goodbye</div>")
+    .appendTo("#qunit-fixture")
+    .bind('showandtell.remove', function(event) {
+      ok(true, "Event triggered");
+      equal(event.namespace, "remove", "remove() is an action");
+    })
+    .bind('showandtell.hide', function(event) {
+      if (event.namespace == "hide")
+        ok(false, "Hide event shouldn't have triggered");
+    })
+    .bind('showandtell.show', function(event) {
+      if (event.namespace == "show")
+        ok(false, "Show event shouldn't have triggered");
+    })
+    .remove();
+});
+
+
+QUnit.test("CSS display none (hide)", function(assert) {
+  expect(6);
+  $("<div>Hello</div><div>Goodbye</div>")
+    .appendTo("#qunit-fixture")
+    .bind('showandtell.cssHide', function(event) {
+      ok(true, "Event triggered");
+      ok($(this).is(":hidden"), "Element is hidden");
+      equal(event.namespace, "cssHide", "CSS change.");
+    })
+    .bind('showandtell.cssShow', function(e) {
+      if (e.namespace == "cssShow")
+        ok(false, "Show event shouldn't be triggered");
+    })
+    .css('display','none');
+});
+
+QUnit.test("CSS display block (show)", function(assert) {
+  expect(6);
+  $('<div style="display: none;">Hello</div><div style="display: none;">Goodbye</div>')
+    .appendTo("#qunit-fixture")
+    .bind('showandtell.cssShow', function(event) {
+      ok(true, "Event triggered");
+      ok($(this).is(":visible"), "Element is visible");
+      equal(event.namespace, "cssShow", "CSS change.");
+    })
+    .bind('showandtell.cssHide', function(e) {
+      if (e.namespace == "cssHide")
+        ok(false, "Hide event shouldn't be triggered");
+    })
+    .css('display','block');
+});

--- a/test/unit/multi-select.js
+++ b/test/unit/multi-select.js
@@ -1,0 +1,22 @@
+module("Multi-Select");
+
+QUnit.test("hide Test (hide)", function(assert) {
+  expect(6);
+  $("<div>Hello</div><div>Goodbye</div>")
+    .appendTo("#qunit-fixture")
+    .bind('showandtell.hide', function(event) {
+      ok(true, "Event triggered");
+      ok($(this).is(":hidden"), "Element is hidden");
+
+      //Check that action and fatality is reported correctly
+      equal(event.namespace, "hide", "hide() is an action");
+    })
+    .bind('showandtell.show', function(event) {
+      if (event.namespace == "show")
+      {
+        //Make sure show event does not trigger!
+        ok(false, "Show event shouldn't have triggered");
+      }
+    })
+    .hide();
+});


### PR DESCRIPTION
Fixes [Issue 14: Hiding multiple elements with a single selector does NOT fire showandtell.hide](https://github.com/hypesystem/showandtell.js/issues/14).

I added 1 new unit to test, but there should be more tests for "multi-selectors", but don't have time at the moment to bone up on QUnit to make sure I'm writing the tests correctly.

All of the existing unit tests that had previously passed continue to pass and the 3 existing unit tests that had previously failed continue to fail.

Also note: I reformatted the code to the style I prefer.  Feel free to change it back to your preferred style.